### PR TITLE
Use traceback splicing to correctly compute global traceback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@ int main(int argc, char** argv) {
     //args::Flag exact_wfa(parser, "N", "compute the exact WFA for base-level WFA, don't use adaptive wavefront reduction", {'E', "exact-wfa"});
     args::Flag align_edlib(parser, "N", "use edlib for base-level alignment", {'a', "edlib-align"});
     args::Flag revcomp_query(parser, "N", "align the reverse complement of the query", {'r', "revcomp-query"});
+    args::Flag no_merge(parser, "N", "don't merge the alignments into a single record (WFA only)", {'M', "no-merge"});
 
     // general parameters
     //args::Flag show_progress(parser, "show-progress", "write alignment progress to stderr", {'P', "show-progress"});
@@ -73,6 +74,7 @@ int main(int argc, char** argv) {
     if (query_sequence_file_list) {
         parse_file_list(args::get(query_sequence_file_list), queries);
     }
+    bool merge_alignments = !args::get(no_merge);
 
     uint64_t segment_length = p_segment_length ? args::get(p_segment_length) : 1000;
     uint64_t min_wavefront_length = wf_min ? args::get(wf_min) : 100;
@@ -114,6 +116,7 @@ int main(int argc, char** argv) {
                             } else {
                                 wflign::wavefront::wflign_affine_wavefront(
                                     std::cout,
+                                    merge_alignments,
                                     qname, qstrand.c_str(), qstrand.size(), 0, qstrand.size(),
                                     revcomp,
                                     tname, tseq.c_str(), tseq.size(), 0, tseq.size(),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
     uint64_t min_wavefront_length = wf_min ? args::get(wf_min) : 100;
     uint64_t step_size = segment_length / 2;
     uint64_t max_distance_threshold = wf_diff ? args::get(wf_diff) / step_size : 100000 / step_size;
-    float min_identity = min_pct_identity ? args::get(min_pct_identity) / 100 : 0.7;
+    float min_identity = min_pct_identity ? args::get(min_pct_identity) / 100 : 0;
 
     // exact WFA is triggered by setting the reduction parameters to 0
     if (args::get(exact_wflign)) {

--- a/src/rkmh.cpp
+++ b/src/rkmh.cpp
@@ -43,30 +43,22 @@ inline void reverse_complement(const char *seq, char *ret, int len) {
  **/
 inline void calc_hashes_(const char *seq, const uint64_t &len,
                          const uint64_t &k, hash_t *&hashes, int numhashes) {
-    char *reverse = new char[k + 1];
+    char reverse[k + 1];
     uint32_t rhash[4];
     uint32_t fhash[4];
-    //hash_t tmp_fwd;
-    //hash_t tmp_rev;
-    //numhashes = (int) (len - k);
-    //hashes = new hash_t[numhashes];
     for (int i = 0; i < numhashes; ++i) {
         if (canonical(seq + i, k)) {
             reverse_complement(seq + i, reverse, k);
             MurmurHash3_x64_128(seq + i, k, 42, fhash);
             MurmurHash3_x64_128(reverse, k, 42, rhash);
-            //hash_t tmp_fwd = *((hash_t*) fhash);
-            //hash_t tmp_rev = *((hash_t*) rhash);
             hash_t tmp_fwd = static_cast<uint64_t>(fhash[0]) << 32 | fhash[1];
             hash_t tmp_rev = static_cast<uint64_t>(rhash[0]) << 32 | rhash[1];
-
             hashes[i] = (tmp_fwd < tmp_rev ? tmp_fwd : tmp_rev);
             //std::cerr << "hashes[" << i << "] = " << hashes[i] << std::endl;
         } else {
             hashes[i] = 0;
         }
     }
-    delete[] reverse;
 };
 
 /* Calculate all the hashes of the kmers length k of seq */

--- a/src/wflign_wfa.cpp
+++ b/src/wflign_wfa.cpp
@@ -311,21 +311,11 @@ bool do_alignment(
             segment_length,
             max_score);
 
-        int match_count = 0;
-        for (int q = affine_wavefronts->edit_cigar.begin_offset;
-             q != affine_wavefronts->edit_cigar.end_offset; ++q) {
-            match_count += affine_wavefronts->edit_cigar.operations[q] == 'M';
-        }
-
-        //aln.identity = std::min(1.0, (double)match_count / ((double)segment_length / 2));
-        aln.identity = (double)match_count / ((double)segment_length);
-        //std::cerr << "identity is " << aln.identity << " and score " << aln.score << std::endl;
-
         aln.j = j;
         aln.i = i;
         aln.mash_dist = mash_dist;
         // copy our edit cigar if we aligned
-        aln.ok = aln.score < max_score && aln.identity > min_identity;
+        aln.ok = aln.score < max_score;
         if (aln.ok) {
             wflign_edit_cigar_copy(&aln.edit_cigar, &affine_wavefronts->edit_cigar);
         }

--- a/src/wflign_wfa.cpp
+++ b/src/wflign_wfa.cpp
@@ -249,8 +249,8 @@ void wflign_affine_wavefront(
                 // we want to remove any possible overlaps in query or target
                 // walk back last until we don't overlap in i or j
                 // recording the distance walked as an additional trim on last
-                while (last_pos.j >= curr_pos.j && last_pos.decr());
-                while (last_pos.i >= curr_pos.i && curr_pos.incr());
+                while (last_pos.j > curr_pos.j && last_pos.decr());
+                while (last_pos.i > curr_pos.i && curr_pos.incr());
                 trim_last = (last.j + segment_length) - last_pos.j;
                 trim_curr = curr_pos.j - curr.j;
                 // TODO the resulting alignment should be convertible to a single record

--- a/src/wflign_wfa.cpp
+++ b/src/wflign_wfa.cpp
@@ -62,8 +62,6 @@ void wflign_affine_wavefront(
     whash::patchmap<uint64_t,alignment_t*> alignments;
 
     // allocate vectors to store our sketches
-    //whash::patchmap<uint64_t, std::vector<rkmh::hash_t>*> query_sketches;
-    //whash::patchmap<uint64_t, std::vector<rkmh::hash_t>*> target_sketches;
     std::vector<std::vector<rkmh::hash_t>*> query_sketches(pattern_length, nullptr);
     std::vector<std::vector<rkmh::hash_t>*> target_sketches(text_length, nullptr);
 
@@ -329,11 +327,11 @@ bool do_alignment(
     double mash_dist = rkmh::compare(*query_sketch, *target_sketch, minhash_kmer_size);
     //std::cerr << "mash_dist = " << mash_dist << std::endl;
 
-    int max_score = segment_length * 0.8;
+    int max_score = segment_length * 1.1;
 
     // the mash distance generally underestimates the actual divergence
     // but when it's high we are almost certain that it's not a match
-    if (mash_dist > 0.1) {
+    if (mash_dist > 0.9) {
         // if it isn't, return false
         aln.score = max_score;
         aln.ok = false;

--- a/src/wflign_wfa.cpp
+++ b/src/wflign_wfa.cpp
@@ -479,7 +479,6 @@ void write_merged_alignment(
                 cigarv.push_back(c);
             }
             cigarv.push_back(cigar);
-            
             last_query_end = aln.j + query_aligned_length;
             last_target_end = aln.i + target_aligned_length;
             total_score += aln.score;
@@ -509,12 +508,6 @@ void write_merged_alignment(
         << "\t" << "ni:i:" << total_insertions
         << "\t" << "nd:i:" << total_deletions
         << "\t" << "cg:Z:";
-    /*
-    for (auto c = cigarv.begin(); c != cigarv.end(); ++c) {
-        out << *c;
-        free(*c);
-    }
-    */
     // cigar op merging
     char last_op = '\0';
     int last_len = 0;

--- a/src/wflign_wfa.hpp
+++ b/src/wflign_wfa.hpp
@@ -25,7 +25,6 @@ struct alignment_t {
     bool ok = false;
     int score = std::numeric_limits<int>::max();
     double mash_dist = 1;
-    double identity = 0;
     int skip_query_start = 0;
     int keep_query_length = 0;
     int skip_target_start = 0;

--- a/src/wflign_wfa.hpp
+++ b/src/wflign_wfa.hpp
@@ -55,6 +55,20 @@ struct trace_pos_t {
             return false;
         }
     }
+    bool decr(void) {
+        if (offset > edit_cigar->begin_offset) {
+            --offset;
+            switch (curr()) {
+            case 'M': case 'X': --j; --i; break;
+            case 'I': --j; break;
+            case 'D': --i; break;
+            default: break;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
     bool at_end(void) const {
         return offset == edit_cigar->end_offset;
     }

--- a/src/wflign_wfa.hpp
+++ b/src/wflign_wfa.hpp
@@ -3,6 +3,8 @@
 #include <cstring>
 #include <vector>
 #include <algorithm>
+#include <cctype>
+#include <charconv>
 #include "WFA/edit/edit_cigar.hpp"
 //#include "WFA/gap_affine/affine_wavefront.hpp"
 #include "WFA/gap_affine/affine_wavefront_align.hpp"

--- a/src/wflign_wfa.hpp
+++ b/src/wflign_wfa.hpp
@@ -35,6 +35,43 @@ struct alignment_t {
     }
 };
 
+// link a position in a traceback matrix to its edit
+struct trace_pos_t {
+    int j = 0;
+    int i = 0;
+    wfa::edit_cigar_t* edit_cigar = nullptr;
+    int offset = 0;
+    bool incr(void) {
+        if (offset < edit_cigar->end_offset) {
+            switch (curr()) {
+            case 'M': case 'X': ++j; ++i; break;
+            case 'I': ++j; break;
+            case 'D': ++i; break;
+            default: break;
+            }
+            ++offset;
+            return true;
+        } else {
+            return false;
+        }
+    }
+    bool at_end(void) const {
+        return offset == edit_cigar->end_offset;
+    }
+    char curr(void) const {
+        assert(!at_end());
+        return edit_cigar->operations[offset];
+    }
+    bool equal(const trace_pos_t& other) const {
+        return j == other.j
+            && i == other.i
+            && curr() == other.curr();
+    }
+    bool assigned(void) const {
+        return edit_cigar != nullptr;
+    }
+};
+
 void wflign_edit_cigar_copy(
     wfa::edit_cigar_t* const edit_cigar_dst,
     wfa::edit_cigar_t* const edit_cigar_src);


### PR DESCRIPTION
This walks the trackback of each segment alignment until it matches the traceback of the subsequent alignment.

Currently this is implemented for wflign::wavefront only, but it should be ported to wflign::edlib as well.