### PR TITLE
expose a filter for minimum gap-compressed alignment dentity

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     args::PositionalList<std::string> query_sequence_files(parser, "queries", "query sequences");
     args::ValueFlag<std::string> query_sequence_file_list(parser, "queries", "alignment query file list", {'Q', "query-file-list"});
     args::ValueFlag<uint64_t> p_segment_length(parser, "N", "segment length for aligning [default: 1000]", {'s', "segment-length"});
-    args::ValueFlag<float> min_pct_identity(parser, "%", "only emit alignments above this percent identity (edlib only) [default: 0]", {'I', "min-pct-id"});
+    args::ValueFlag<float> min_pct_identity(parser, "%", "only emit alignments above this percent identity [default: 0]", {'I', "min-pct-id"});
     args::ValueFlag<int> wf_min(parser, "N", "WFlambda_min: minimum length of a wavefront to trigger reduction [default: 100]", {'l', "wf-min"});
     args::ValueFlag<int> wf_diff(parser, "N", "WFlambda_diff: maximum distance in bp that a wavefront may be behind the best wavefront to not be reduced [default: 100000]", {'d', "wf-diff"});
     args::Flag exact_wflign(parser, "N", "compute the exact WFA for wflign, don't use adaptive wavefront reduction", {'e', "exact-wflign"});
@@ -121,6 +121,7 @@ int main(int argc, char** argv) {
                                     revcomp,
                                     tname, tseq.c_str(), tseq.size(), 0, tseq.size(),
                                     segment_length,
+                                    min_identity,
                                     min_wavefront_length,
                                     max_distance_threshold);
                             }

--- a/src/wflign_wfa.hpp
+++ b/src/wflign_wfa.hpp
@@ -157,6 +157,7 @@ void wflign_affine_wavefront(
     const uint64_t& target_offset,
     const uint64_t& target_length,
     const uint64_t& segment_length,
+    const float& min_identity,
     const int& wflambda_min_wavefront_length, // with these set at 0 we do exact WFA for wflambda
     const int& wflambda_max_distance_threshold);
     //const int& wfa_min_wavefront_length, // with these set at 0 we do exact WFA for WFA itself
@@ -198,6 +199,7 @@ void write_merged_alignment(
     const uint64_t& target_total_length,
     const uint64_t& target_offset,
     const uint64_t& target_length,
+    const float& min_identity,
     const bool& with_endline = true);
 
 void write_alignment(
@@ -212,6 +214,7 @@ void write_alignment(
     const uint64_t& target_total_length,
     const uint64_t& target_offset,
     const uint64_t& target_length,
+    const float& min_identity,
     const bool& with_endline = true);
 
 


### PR DESCRIPTION
Alignments with identity less than our expected threshold may be associated with error. This allows filtering them at the point of alignment identity computation.